### PR TITLE
[bugfix] Add check for `\SoapFault::$detail`

### DIFF
--- a/library/Vmwarephp/Exception/Soap.php
+++ b/library/Vmwarephp/Exception/Soap.php
@@ -22,11 +22,16 @@ class Soap extends \Exception {
 		return "{$soapFault->faultcode}: {$soapFault->faultstring}. ";
 	}
 
-	private function makeFaultDetailsString($soapFault) {
+	private function makeFaultDetailsString(\SoapFault $soapFault) {
 		$faults = array();
-		foreach ($soapFault->detail as $fault) {
-			$faults[] = "{$fault->enc_stype}: " . print_r($fault->enc_value, true);
-		}
-		return count($faults) ? implode(', ', $faults) : '';
+        // \SoapFault::$detail property can be unexistent
+        // @link https://bugs.php.net/bug.php?id=46792
+        if (isset($soapFault->detail)) {
+            foreach ($soapFault->detail as $fault) {
+                $faults[] = "{$fault->enc_stype}: " . print_r($fault->enc_value, true);
+            }
+        }
+
+		return implode(', ', $faults);
 	}
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Add check for existence of `\SoapFault::$detail` property  in `Vmwarephp\Exception\Soap::makeFaultDetailsString()`
since it can be unset.